### PR TITLE
Offboard Luis Padilla

### DIFF
--- a/folks.yml
+++ b/folks.yml
@@ -104,11 +104,6 @@
   github: adam-kramer
   npm: adam-kramer
 
-- name: Luis Padilla
-  username: luis.padilla
-  github: missaelpadilla07
-  npm: missaelpadilla07
-
 - name: Malik Inkatha
   username: malik.inkatha
   github: inkatha

--- a/keys/luis-padilla.pub
+++ b/keys/luis-padilla.pub
@@ -1,1 +1,0 @@
-ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJGINz3OZnSLrjwJt+xx1g155DySznX/K9DMNdyJZ14z luis.padilla@goodeggs.com


### PR DESCRIPTION
This removes Luis Padilla's entries in `folks.yml` and the corresponding public key. Md Rabbani, being offboarded at the same time, is not mentioned in this repo.